### PR TITLE
Add human time parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -609,6 +609,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
 name = "hyper"
 version = "0.14.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2017,6 +2023,7 @@ dependencies = [
  "clap_mangen",
  "configparser",
  "file-owner",
+ "humantime",
  "ipnet",
  "pnet",
  "port_check",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ tokio = { version = "1", features = ["rt-multi-thread", "macros", "process", "fs
 tracing = { version = "0.1", features = ["log"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 wireguard-keys = "0.1"
+humantime = "2.1.0"
 
 [dev-dependencies]
 rstest = "0.17"

--- a/README.md
+++ b/README.md
@@ -63,9 +63,11 @@ By default, peers that we haven't received a handshake from within 10 minutes ar
               [default: wiresmith]
 
       -u, --update-period <UPDATE_PERIOD>
-              Update period - how often to check for peer updates in seconds
+              Update period - how often to check for peer updates
 
-              [default: 10]
+              Parses human-friendly time, e.g. 15s
+
+              [default: 10s]
 
       -i, --wg-interface <WG_INTERFACE>
               WireGuard interface name
@@ -78,11 +80,12 @@ By default, peers that we haven't received a handshake from within 10 minutes ar
               [default: 51820]
 
       -t, --peer-timeout <PEER_TIMEOUT>
-              Remove disconnected peers after this many minutes
+              Remove disconnected peers after this duration
 
+              Parses human-friendly time, e.g. 5min
               Set to 0 in order to disable.
 
-              [default: 10]
+              [default: 10min]
 
           --endpoint-interface <ENDPOINT_INTERFACE>
               Public endpoint interface name

--- a/interactive_test.kdl
+++ b/interactive_test.kdl
@@ -9,19 +9,19 @@ layout {
             pane {
                 name "wiresmith1"
                 command "podman"
-                args "exec" "wiresmith1" "bash" "-c" "sleep 2 && wiresmith --consul-address http://10.0.2.2:8500 --network 10.0.0.0/24 --endpoint-address 10.0.2.2 --update-period 1 --peer-timeout 3 -p 11111 -v"
+                args "exec" "wiresmith1" "bash" "-c" "sleep 2 && wiresmith --consul-address http://10.0.2.2:8500 --network 10.0.0.0/24 --endpoint-address 10.0.2.2 --update-period 1s --peer-timeout 3min -p 11111 -v"
             }
         }
         pane {
             pane {
                 name "wiresmith2"
                 command "podman"
-                args "exec" "wiresmith2" "bash" "-c" "sleep 2 && wiresmith --consul-address http://10.0.2.2:8500 --network 10.0.0.0/24 --endpoint-address 10.0.2.2 --update-period 1 --peer-timeout 3 -p 22222 -v"
+                args "exec" "wiresmith2" "bash" "-c" "sleep 2 && wiresmith --consul-address http://10.0.2.2:8500 --network 10.0.0.0/24 --endpoint-address 10.0.2.2 --update-period 1s --peer-timeout 3min -p 22222 -v"
             }
             pane {
                 name "wiresmith3"
                 command "podman"
-                args "exec" "wiresmith3" "bash" "-c" "sleep 2 && wiresmith --consul-address http://10.0.2.2:8500 --network 10.0.0.0/24 --endpoint-address 10.0.2.2 --update-period 1 --peer-timeout 3 -p 33333 -v"
+                args "exec" "wiresmith3" "bash" "-c" "sleep 2 && wiresmith --consul-address http://10.0.2.2:8500 --network 10.0.0.0/24 --endpoint-address 10.0.2.2 --update-period 1s --peer-timeout 3min -p 33333 -v"
             }
         }
     }

--- a/src/args.rs
+++ b/src/args.rs
@@ -26,8 +26,8 @@ pub struct CliArgs {
     #[arg(long, default_value = "wiresmith")]
     pub consul_prefix: String,
 
-    /// Update period - how often to check for peer updates in seconds
-    #[arg(short, long, default_value = "10", value_parser = duration_seconds)]
+    /// Update period - how often to check for peer updates
+    #[arg(short, long, default_value = "10s", value_parser = humantime::parse_duration)]
     pub update_period: Duration,
 
     /// WireGuard interface name
@@ -38,10 +38,10 @@ pub struct CliArgs {
     #[arg(short = 'p', long, default_value = "51820")]
     pub wg_port: u16,
 
-    /// Remove disconnected peers after this many minutes
+    /// Remove disconnected peers after this duration
     ///
     /// Set to 0 in order to disable.
-    #[arg(short = 't', long, default_value = "10", value_parser = duration_minutes)]
+    #[arg(short = 't', long, default_value = "10min", value_parser = humantime::parse_duration)]
     pub peer_timeout: Duration,
 
     /// Public endpoint interface name
@@ -103,14 +103,4 @@ fn network_interface(s: &str) -> Result<NetworkInterface, String> {
         Some(i) => Ok(i.clone()),
         None => Err(format!("No usable interface found for '{}'", s)),
     }
-}
-
-fn duration_seconds(s: &str) -> Result<Duration, String> {
-    let dur: u64 = s.parse().map_err(|_| format!("Invalid number: {s}"))?;
-    Ok(Duration::from_secs(dur))
-}
-
-fn duration_minutes(s: &str) -> Result<Duration, String> {
-    let dur: u64 = s.parse().map_err(|_| format!("Invalid number: {s}"))?;
-    Ok(Duration::from_secs(dur * 60))
 }

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -86,7 +86,7 @@ impl WiresmithContainer {
             .arg("--endpoint-address")
             .arg(endpoint_address)
             .arg("--update-period")
-            .arg("1")
+            .arg("1s")
             // To diagnose issues, it's sometimes helpful to comment out the following line so that
             // we can see log output from the wiresmith instances inside the containers.
             .stdout(Stdio::null())


### PR DESCRIPTION
This PR adds human time parsing for the `peer_timeout` argument. @svenstaro Should this be used for the `update_interval` as well?