### PR TITLE
Use keepalives instead of handshakes for timeouts

### DIFF
--- a/interactive_test.kdl
+++ b/interactive_test.kdl
@@ -9,19 +9,19 @@ layout {
             pane {
                 name "wiresmith1"
                 command "podman"
-                args "exec" "wiresmith1" "bash" "-c" "sleep 2 && wiresmith --consul-address http://10.0.2.2:8500 --network 10.0.0.0/24 --endpoint-address 10.0.2.2 --update-period 1s --peer-timeout 3min -p 11111 -v"
+                args "exec" "wiresmith1" "bash" "-c" "sleep 2 && wiresmith --consul-address http://10.0.2.2:8500 --network 10.0.0.0/24 --endpoint-address 10.0.2.2 --update-period 1s --peer-timeout 10s --keepalive 2s -p 11111 -v"
             }
         }
         pane {
             pane {
                 name "wiresmith2"
                 command "podman"
-                args "exec" "wiresmith2" "bash" "-c" "sleep 2 && wiresmith --consul-address http://10.0.2.2:8500 --network 10.0.0.0/24 --endpoint-address 10.0.2.2 --update-period 1s --peer-timeout 3min -p 22222 -v"
+                args "exec" "wiresmith2" "bash" "-c" "sleep 2 && wiresmith --consul-address http://10.0.2.2:8500 --network 10.0.0.0/24 --endpoint-address 10.0.2.2 --update-period 1s --peer-timeout 10s --keepalive 2s -p 22222 -v"
             }
             pane {
                 name "wiresmith3"
                 command "podman"
-                args "exec" "wiresmith3" "bash" "-c" "sleep 2 && wiresmith --consul-address http://10.0.2.2:8500 --network 10.0.0.0/24 --endpoint-address 10.0.2.2 --update-period 1s --peer-timeout 3min -p 33333 -v"
+                args "exec" "wiresmith3" "bash" "-c" "sleep 2 && wiresmith --consul-address http://10.0.2.2:8500 --network 10.0.0.0/24 --endpoint-address 10.0.2.2 --update-period 1s --peer-timeout 10s --keepalive 2s -p 33333 -v"
             }
         }
     }

--- a/src/args.rs
+++ b/src/args.rs
@@ -44,6 +44,12 @@ pub struct CliArgs {
     #[arg(short = 't', long, default_value = "10min", value_parser = humantime::parse_duration)]
     pub peer_timeout: Duration,
 
+    /// Set persistent keepalive option for wireguard
+    ///
+    /// Set to 0 in order to disable.
+    #[arg(short = 'k', long, default_value = "25s", value_parser = keep_alive)]
+    pub keepalive: u64,
+
     /// Public endpoint interface name
     ///
     /// You need to provide either this or --endpoint-address.
@@ -103,4 +109,9 @@ fn network_interface(s: &str) -> Result<NetworkInterface, String> {
         Some(i) => Ok(i.clone()),
         None => Err(format!("No usable interface found for '{}'", s)),
     }
+}
+
+fn keep_alive(s: &str) -> Result<u64, humantime::DurationError> {
+    let duration = humantime::parse_duration(s)?;
+    Ok(duration.as_secs())
 }

--- a/src/networkd.rs
+++ b/src/networkd.rs
@@ -139,7 +139,7 @@ impl NetworkdConfiguration {
 
     /// Generate and write systemd-networkd config
     #[tracing::instrument]
-    pub async fn write_config(&self, networkd_dir: &Path) -> Result<()> {
+    pub async fn write_config(&self, networkd_dir: &Path, persistent_keepalive: u64) -> Result<()> {
         let network_file = format!(
             "\
 [Match]
@@ -171,8 +171,8 @@ PrivateKey={}\n",
 PublicKey={}
 Endpoint={}
 AllowedIPs={}
-PersistentKeepalive=25",
-                peer.public_key, peer.endpoint, peer.address
+PersistentKeepalive={}",
+                peer.public_key, peer.endpoint, peer.address, persistent_keepalive
             );
             netdev_file.push_str(&peer_str);
         }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -56,6 +56,7 @@ async fn initial_configuration(#[future] consul: ConsulContainer, tmpdir: TempDi
         "10.0.0.0/24",
         "192.168.0.1",
         consul.http_port,
+        &[],
         &tmpdir,
     )
     .await;
@@ -202,6 +203,7 @@ async fn join_network(
         "10.0.0.0/24",
         "192.168.0.1",
         consul.http_port,
+        &[],
         &tmpdir_a,
     )
     .await;
@@ -223,6 +225,7 @@ async fn join_network(
         "10.0.0.0/24",
         "192.168.0.2",
         consul.http_port,
+        &[],
         &tmpdir_b,
     )
     .await;
@@ -276,6 +279,7 @@ async fn join_network(
         "10.0.0.0/24",
         "192.168.0.3",
         consul.http_port,
+        &[],
         &tmpdir_c,
     )
     .await;

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -24,6 +24,7 @@ pub async fn wait_for_files(files: Vec<&Path>) {
     );
 }
 
+#[derive(PartialEq)]
 pub struct WiresmithContainer {
     /// Full unique container_name
     ///
@@ -38,6 +39,7 @@ impl WiresmithContainer {
         network: &str,
         endpoint_address: &str,
         consul_port: u16,
+        args: &[&str],
         dir: &Path,
     ) -> Self {
         let container_name = format!("{name}-{consul_port}");
@@ -87,6 +89,7 @@ impl WiresmithContainer {
             .arg(endpoint_address)
             .arg("--update-period")
             .arg("1s")
+            .args(args.clone())
             // To diagnose issues, it's sometimes helpful to comment out the following line so that
             // we can see log output from the wiresmith instances inside the containers.
             .stdout(Stdio::null())


### PR DESCRIPTION
This PR introduces the use of keepalives instead of handshakes via wireguard. Handshakes are made approx. every minute, keepalives are configurable. This way we can test a peer deletion without waiting for a handshake. This also allows us to introduce tighter timeout intervals, as the lower bound isn't fixed to one minute anymore.