### PR TITLE
Fix test container network setup

### DIFF
--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -38,6 +38,7 @@ impl WiresmithContainer {
         name: &str,
         network: &str,
         endpoint_address: &str,
+        port: u16,
         consul_port: u16,
         args: &[&str],
         dir: &Path,
@@ -57,7 +58,9 @@ impl WiresmithContainer {
             // SYS_ADMIN could be removed when https://github.com/systemd/systemd/pull/26478 is released
             .arg("SYS_ADMIN,NET_ADMIN")
             .arg("--network")
-            .arg(format!("container:consul-{consul_port}"))
+            .arg("slirp4netns:allow_host_loopback=true")
+            .arg("-p")
+            .arg(format!("{port}:{port}/udp"))
             .arg("-v")
             .arg(concat!(
                 env!("CARGO_BIN_EXE_wiresmith"),
@@ -82,13 +85,15 @@ impl WiresmithContainer {
             .arg(&container_name)
             .arg("wiresmith")
             .arg("--consul-address")
-            .arg(format!("http://consul-{consul_port}:{consul_port}"))
+            .arg(format!("http://10.0.2.2:{consul_port}"))
             .arg("--network")
             .arg(network)
             .arg("--endpoint-address")
             .arg(endpoint_address)
             .arg("--update-period")
             .arg("1s")
+            .arg("-p")
+            .arg(port.to_string())
             .args(args.clone())
             // To diagnose issues, it's sometimes helpful to comment out the following line so that
             // we can see log output from the wiresmith instances inside the containers.

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -37,7 +37,6 @@ impl WiresmithContainer {
     pub async fn new(
         name: &str,
         network: &str,
-        endpoint_address: &str,
         port: u16,
         consul_port: u16,
         args: &[&str],
@@ -89,7 +88,7 @@ impl WiresmithContainer {
             .arg("--network")
             .arg(network)
             .arg("--endpoint-address")
-            .arg(endpoint_address)
+            .arg("10.0.2.2")
             .arg("--update-period")
             .arg("1s")
             .arg("-p")


### PR DESCRIPTION
The network setup of the test containers were faulty. In between containers there were no wireguard handshakes and keep alives during the tests. This PR fixes this by using the same network setup the `just interactive` test does.
I couldn't figure out what the exact problem was. The main issue I found was that restarting `systemd-networkd` inside a container restarted it in every other container running `wiresmith`. After the restart every container used the netdev configuration of the one single container which restarted its `systemd-networkd`.