### PR TITLE
Adjust network setup

### DIFF
--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -37,7 +37,6 @@ impl WiresmithContainer {
     pub async fn new(
         name: &str,
         network: &str,
-        endpoint_address: &str,
         consul_port: u16,
         args: &[&str],
         dir: &Path,
@@ -57,7 +56,7 @@ impl WiresmithContainer {
             // SYS_ADMIN could be removed when https://github.com/systemd/systemd/pull/26478 is released
             .arg("SYS_ADMIN,NET_ADMIN")
             .arg("--network")
-            .arg(format!("container:consul-{consul_port}"))
+            .arg(format!("wiresmith-{consul_port}"))
             .arg("-v")
             .arg(concat!(
                 env!("CARGO_BIN_EXE_wiresmith"),
@@ -86,7 +85,7 @@ impl WiresmithContainer {
             .arg("--network")
             .arg(network)
             .arg("--endpoint-address")
-            .arg(endpoint_address)
+            .arg(&container_name)
             .arg("--update-period")
             .arg("1s")
             .args(args.clone())


### PR DESCRIPTION
This PR adjusts the network setup of the test containers and solves the folowing observed problems:
- no handshakes/keepalives between the wireguards of the containers
- `systemctl restart systemd-networkd` in one container effected all containers
- generally faulty wireguard configurations (all wiresmith containers used the same network configuration file)

**All screenshots were made of the containers running via the `join_network` test which was just halted forever.**

## Old approach

The old approach connected all `wiresmith` containers to the `consul` containers network via podman's `--network` flag. This led to an overall faulty network configuration where different container would have the same IP address inside this virtual network. Furthermore the `endpoint_address` was only set inside `wiresmith`, not for the container itself. This led to missing handshakes/keepalives due to `wiresmith` not using the actual `endpoint_address`.

Old container setup:
![image](https://github.com/svenstaro/wiresmith/assets/70777530/dce3a72e-dc6a-4740-90ed-0f6888ae85b9)

Same IP addresses:
![image](https://github.com/svenstaro/wiresmith/assets/70777530/5001aac6-d26d-46fb-9eb3-fd1620652779)

All containers use the same wireguard config. There are no handshakes/keepalives:
![image](https://github.com/svenstaro/wiresmith/assets/70777530/f4500968-d2a4-4b15-8290-b220f36c67f4)

## New approach

The new approach uses an explicitly created network. Each container joins this network and is assigned a unique IP address. We are also able to use the name of the respective container for the `endpoint_address` via DNS.

New container setup:
![image](https://github.com/svenstaro/wiresmith/assets/70777530/66a316b3-b1ff-4d4a-8bb1-f3eaddd667d0)

Unique IP addresses:
![image](https://github.com/svenstaro/wiresmith/assets/70777530/697de260-8647-4d4d-ae0f-335b975818fe)

All containers use their own wireguard config. Handshakes and keepalives are happening:
![image](https://github.com/svenstaro/wiresmith/assets/70777530/ff160a77-2de5-494e-94f4-d0a878b5b526)

I really like that the new setup doesn't use port forwarding on the wiresmith containers but the consul container (and therefore the webpage) is still forwarded.