### PR TITLE
Fix flaky test

### DIFF
--- a/tests/fixtures/mod.rs
+++ b/tests/fixtures/mod.rs
@@ -119,6 +119,9 @@ where
         .spawn()
         .expect("Couldn't create test container network");
 
+    // Wait for podman to setup the network.
+    sleep(Duration::from_millis(100)).await;
+
     Command::new("podman")
         .arg("run")
         .arg("--name")

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -86,8 +86,6 @@ impl WiresmithContainer {
             .arg(network)
             .arg("--endpoint-address")
             .arg(&container_name)
-            .arg("--update-period")
-            .arg("1s")
             .args(args.clone())
             // To diagnose issues, it's sometimes helpful to comment out the following line so that
             // we can see log output from the wiresmith instances inside the containers.


### PR DESCRIPTION
This PR reduces the peer amount of the `deletes_peer_on_timeout` test from three to two. I didn't find a way to reduce the flakiness which was caused by `systemd-networkd` restarting multiple times in a short amount of time. By reducing the amount of peers to two we can still check the timeout logic and also reduce the flakiness together with the test duration significantly (currently running successfully since 30 minutes).

I would argue that this is worth the removal of one peer but please tell me if you are okay with that.