### PR TITLE
Remove self from Consul state on shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 <!-- next-header -->
 
 ## [Unreleased] - ReleaseDate
+- Remove self from the Consul state when wiresmith shuts down [#200](https://github.com/svenstaro/wiresmith/pull/200) (thanks @kyrias)
 
 ## [0.3.0] - 2024-04-12
 - Use latest data transmission date instead of latest handshake for timeouts [#17](https://github.com/svenstaro/wiresmith/pull/17) (thanks @tomgroenwoldt)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ pnet = "0.34"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
-tokio = { version = "1", features = ["rt-multi-thread", "macros", "process", "fs"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "process", "fs", "signal"] }
 tracing = { version = "0.1", features = ["log"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 wireguard-keys = "0.1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,7 +63,6 @@ async fn main() -> Result<()> {
         unreachable!("Should have been handled by arg parsing");
     };
 
-    consul_client.acquire_lock().await?;
     info!("Getting existing peers from Consul");
     let peers = consul_client.get_peers().await?;
     if peers.is_empty() {
@@ -98,7 +97,6 @@ async fn main() -> Result<()> {
 
     info!("Restarting systemd-networkd");
     NetworkdConfiguration::restart().await?;
-    consul_client.drop_lock().await?;
 
     // Stores amount of received bytes together with a timestamp for every peer.
     let mut received_bytes: HashMap<wireguard_keys::Pubkey, (usize, Instant)> = HashMap::new();
@@ -133,7 +131,6 @@ async fn main() -> Result<()> {
             }
         }
 
-        consul_client.acquire_lock().await?;
         trace!("Checking Consul for peer updates");
         let peers = consul_client
             .get_peers()
@@ -206,7 +203,6 @@ async fn main() -> Result<()> {
                 .context("Failed to put peer config into Consul")?;
             info!("Wrote own WireGuard peer config to Consul");
         }
-        consul_client.drop_lock().await?;
 
         sleep(args.update_period).await;
     }


### PR DESCRIPTION
This PR has wiresmith create and maintain a Consul session, then when we create the wireguard peer key in Consul we do so using a lock with our session ID.  Due to the way we configure the session this means that Consul will on its own delete the key if the session is either destroyed or invalidated due to us failing to renew it in time, e.g. because we crashed.

On `SIGINT` we explicitly destroy the session, causing Consul to immediately delete the key.