### PR TITLE
BREAKING: Rework Consul integration to use sessions and work across datacenters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased] - ReleaseDate
 - Remove self from the Consul state when wiresmith shuts down [#200](https://github.com/svenstaro/wiresmith/pull/200) (thanks @kyrias)
+- Breaking: Rework Consul integration to use sessions and work across datacenters. This is a breaking change for setups that connect a mesh across Consul datacenters. [#207](https://github.com/svenstaro/wiresmith/pull/207)
 
 ## [0.3.0] - 2024-04-12
 - Use latest data transmission date instead of latest handshake for timeouts [#17](https://github.com/svenstaro/wiresmith/pull/17) (thanks @tomgroenwoldt)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1685,6 +1685,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-util"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cf6b47b3771c49ac75ad09a6162f53ad4b8088b76ac60e8ec1455b31a189fe1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1851,6 +1864,15 @@ name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
+name = "uuid"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5de17fd2f7da591098415cff336e12965a28061ddace43b59cb3c430179c9439"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "valuable"
@@ -2201,6 +2223,7 @@ dependencies = [
  "clap_mangen",
  "configparser",
  "file-owner",
+ "futures",
  "humantime",
  "ipnet",
  "pnet",
@@ -2213,8 +2236,10 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tokio-util",
  "tracing",
  "tracing-subscriber",
+ "uuid",
  "wireguard-keys",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,9 @@ tracing = { version = "0.1", features = ["log"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 wireguard-keys = "0.1"
 humantime = "2.1.0"
+uuid = { version = "1.8.0", features = ["serde"] }
+tokio-util = "0.7.11"
+futures = "0.3.30"
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ can also clean up dead peers if desired.
 - Automatic address allocation
 - Mesh connectivity
 - IPv4/IPv6
-- Value store backends: Consul (with datacenter selection for federated clusters)
+- Value store backends: Consul
 - Network configuration backends: systemd-networkd
 - Cleanup of dead peers
 - Pretty logging!
@@ -39,7 +39,10 @@ This will:
 
 The endpoint interface needs to be reachable from all the other peers.
 
-By default, peers that we haven't received a handshake from within 10 minutes are removed.
+If you use [Consul
+Federation](https://developer.hashicorp.com/consul/tutorials/networking/federation-gossip-wan)
+we fetch peers from all available datacenters using the same `--consul-prefix`
+value.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,11 @@ regardless of where the request is coming from.
           --consul-token <CONSUL_TOKEN>
               Consul secret token
 
+          --consul-ttl <CONSUL_TTL>
+              Consul TTL times out after this duration without being renewed
+
+              [default: 1min]
+
           --consul-prefix <CONSUL_PREFIX>
               Consul KV prefix
 

--- a/README.md
+++ b/README.md
@@ -41,13 +41,6 @@ The endpoint interface needs to be reachable from all the other peers.
 
 By default, peers that we haven't received a handshake from within 10 minutes are removed.
 
-If you use [Consul
-Federation](https://developer.hashicorp.com/consul/tutorials/networking/federation-gossip-wan), be
-aware that Consul KV keys aren't automatically replicated amongst datacenters. In this case, it is
-recommended to select a datacenter to be the single source of truth for Wiresmith. You can use the
-`--consul-datacenter` flag in that case to make sure that the same datacenter is always selected
-regardless of where the request is coming from.
-
 ## Usage
 
     Auto-config WireGuard clients into a mesh
@@ -72,9 +65,6 @@ regardless of where the request is coming from.
               Consul KV prefix
 
               [default: wiresmith]
-
-          --consul-datacenter <CONSUL_DATACENTER>
-              Consul datacenter
 
       -u, --update-period <UPDATE_PERIOD>
               Update period - how often to check for peer updates

--- a/README.md
+++ b/README.md
@@ -91,13 +91,6 @@ regardless of where the request is coming from.
 
               [default: 51820]
 
-      -t, --peer-timeout <PEER_TIMEOUT>
-              Remove disconnected peers after this duration
-
-              Set to 0 in order to disable.
-
-              [default: 10min]
-
       -k, --keepalive <KEEPALIVE>
               Set persistent keepalive option for wireguard
 

--- a/interactive_test.kdl
+++ b/interactive_test.kdl
@@ -9,19 +9,19 @@ layout {
             pane {
                 name "wiresmith1"
                 command "podman"
-                args "exec" "wiresmith1" "bash" "-c" "sleep 2 && wiresmith --consul-address http://10.0.2.2:8500 --network 10.0.0.0/24 --endpoint-address 10.0.2.2 --update-period 1s --peer-timeout 3s --keepalive 1s -p 11111 -v"
+                args "exec" "wiresmith1" "bash" "-c" "sleep 2 && wiresmith --consul-address http://10.0.2.2:8500 --network 10.0.0.0/24 --endpoint-address 10.0.2.2 --update-period 1s --keepalive 1s -p 11111 -v"
             }
         }
         pane {
             pane {
                 name "wiresmith2"
                 command "podman"
-                args "exec" "wiresmith2" "bash" "-c" "sleep 2 && wiresmith --consul-address http://10.0.2.2:8500 --network 10.0.0.0/24 --endpoint-address 10.0.2.2 --update-period 1s --peer-timeout 3s --keepalive 1s -p 22222 -v"
+                args "exec" "wiresmith2" "bash" "-c" "sleep 2 && wiresmith --consul-address http://10.0.2.2:8500 --network 10.0.0.0/24 --endpoint-address 10.0.2.2 --update-period 1s --keepalive 1s -p 22222 -v"
             }
             pane {
                 name "wiresmith3"
                 command "podman"
-                args "exec" "wiresmith3" "bash" "-c" "sleep 2 && wiresmith --consul-address http://10.0.2.2:8500 --network 10.0.0.0/24 --endpoint-address 10.0.2.2 --update-period 1s --peer-timeout 3s --keepalive 1s -p 33333 -v"
+                args "exec" "wiresmith3" "bash" "-c" "sleep 2 && wiresmith --consul-address http://10.0.2.2:8500 --network 10.0.0.0/24 --endpoint-address 10.0.2.2 --update-period 1s --keepalive 1s -p 33333 -v"
             }
         }
     }

--- a/src/args.rs
+++ b/src/args.rs
@@ -22,6 +22,10 @@ pub struct CliArgs {
     #[arg(long)]
     pub consul_token: Option<String>,
 
+    /// Consul TTL times out after this duration without being renewed
+    #[arg(long, default_value = "1min", value_parser = humantime::parse_duration)]
+    pub consul_ttl: Duration,
+
     /// Consul KV prefix
     #[arg(long, default_value = "wiresmith")]
     pub consul_prefix: String,

--- a/src/args.rs
+++ b/src/args.rs
@@ -46,12 +46,6 @@ pub struct CliArgs {
     #[arg(short = 'p', long, default_value = "51820")]
     pub wg_port: u16,
 
-    /// Remove disconnected peers after this duration
-    ///
-    /// Set to 0 in order to disable.
-    #[arg(short = 't', long, default_value = "10min", value_parser = humantime::parse_duration)]
-    pub peer_timeout: Duration,
-
     /// Set persistent keepalive option for wireguard
     ///
     /// Set to 0 in order to disable.

--- a/src/args.rs
+++ b/src/args.rs
@@ -30,10 +30,6 @@ pub struct CliArgs {
     #[arg(long, default_value = "wiresmith")]
     pub consul_prefix: String,
 
-    /// Consul datacenter
-    #[arg(long)]
-    pub consul_datacenter: Option<String>,
-
     /// Update period - how often to check for peer updates
     #[arg(short, long, default_value = "10s", value_parser = humantime::parse_duration)]
     pub update_period: Duration,

--- a/src/consul.rs
+++ b/src/consul.rs
@@ -1,20 +1,24 @@
-use std::collections::HashSet;
+use std::{collections::HashSet, future::Future, time::Duration};
 
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use base64::prelude::{Engine as _, BASE64_STANDARD};
 use reqwest::{
     header::{HeaderMap, HeaderName, HeaderValue},
     StatusCode, Url,
 };
-use serde::Deserialize;
-use tracing::info;
+use serde::{Deserialize, Serialize};
+use tokio::{task::JoinHandle, time::interval};
+use tokio_util::sync::CancellationToken;
+use tracing::{error, info, trace, warn};
+use uuid::Uuid;
 use wireguard_keys::Pubkey;
 
 use crate::wireguard::WgPeer;
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct ConsulClient {
     pub http_client: reqwest::Client,
+    api_base_url: Url,
     pub kv_api_base_url: Url,
     pub datacenter: Option<String>,
 }
@@ -28,6 +32,59 @@ pub struct ConsulKvGet {
     pub lock_index: u64,
     pub modify_index: u64,
     pub value: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "lowercase")]
+enum SessionInvalidationBehavior {
+    /// Delete the keys corresponding to the locks held by this session when the session is
+    /// invalidated.
+    Delete,
+}
+
+#[derive(Copy, Clone)]
+enum SessionDuration {
+    Seconds(u32),
+}
+
+impl TryFrom<Duration> for SessionDuration {
+    type Error = anyhow::Error;
+
+    fn try_from(value: Duration) -> Result<Self> {
+        // Consul only supports durations of up to 86400 seconds.
+        let secs = value.as_secs();
+        if secs > 86400 {
+            bail!("Tried to convert a duration longer than 24 hours into SessionDuration");
+        }
+        Ok(SessionDuration::Seconds(secs as u32))
+    }
+}
+
+impl Serialize for SessionDuration {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&match self {
+            Self::Seconds(s) => format!("{s}s"),
+        })
+    }
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "PascalCase")]
+struct CreateSession {
+    name: String,
+    behavior: SessionInvalidationBehavior,
+    /// How long the session will survive without being renewed.
+    #[serde(rename = "TTL")]
+    ttl: SessionDuration,
+}
+
+#[derive(Deserialize)]
+struct CreateSessionResponse {
+    #[serde(rename = "ID")]
+    id: Uuid,
 }
 
 impl ConsulClient {
@@ -64,6 +121,7 @@ impl ConsulClient {
 
         Ok(ConsulClient {
             http_client: client,
+            api_base_url: consul_address,
             kv_api_base_url,
             datacenter: consul_datacenter,
         })
@@ -154,4 +212,118 @@ impl ConsulClient {
         );
         Ok(())
     }
+
+    /// # Create a Consul session
+    ///
+    /// This starts a background task which renews the session based on the given session TTL. If
+    /// renewing the session fails, the passed in cancellation token is cancelled. On cancellation
+    /// the keys that locks are held for are deleted.
+    ///
+    /// See [`ConsulSession`] for more information.
+    pub async fn create_session(
+        &self,
+        public_key: Pubkey,
+        ttl: Duration,
+        token: CancellationToken,
+    ) -> Result<ConsulSession> {
+        let url = self.api_base_url.join("v1/session/create")?;
+
+        let res = self
+            .http_client
+            .put(url)
+            .json(&CreateSession {
+                name: format!("wiresmith-{}", public_key.to_base64_urlsafe()),
+                behavior: SessionInvalidationBehavior::Delete,
+                ttl: ttl.try_into()?,
+            })
+            .send()
+            .await?
+            .error_for_status()?
+            .json::<CreateSessionResponse>()
+            .await?;
+
+        let join_handle = tokio::spawn(
+            session_handler(self.clone(), token, res.id, ttl)
+                .context("failed to create Consul session handler")?,
+        );
+
+        Ok(ConsulSession { join_handle })
+    }
+}
+
+
+pub struct ConsulSession {
+    pub join_handle: JoinHandle<()>,
+}
+
+/// # Create a background task maintaining a Consul session
+///
+/// This function returns a future which will renew the given Consul session according to the given
+/// session TTL. The returned future is expected to be spawned as a Tokio task.
+///
+/// The future will continue maintaining the session until either the `session_token`
+/// [`CancellationToken`] is cancelled, in which case we will explicitly invalidate the session, or
+/// until the session is invalidated by a third party, in which case the `parent_token` will be
+/// cancelled to let the rest of the application know that the session is no longer valid.
+fn session_handler(
+    client: ConsulClient,
+    token: CancellationToken,
+    id: Uuid,
+    ttl: Duration,
+) -> Result<impl Future<Output = ()> + Send> {
+    // We construct the URLs first so we can return an error before the task is even spawned.
+    let id = id.to_string();
+    let renewal_url = client
+        .api_base_url
+        .join("v1/session/renew/")
+        .context("failed to build session renewal URL")?
+        .join(&id)
+        .context("failed to build session renewal URL")?;
+    let destroy_url = client
+        .api_base_url
+        .join("v1/session/destroy/")
+        .context("failed to build session destroy URL")?
+        .join(&id)
+        .context("failed to build session destroy URL")?;
+
+    Ok(async move {
+        // Renew the session at 2 times the TTL.
+        let mut interval = interval(ttl / 2);
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+        loop {
+            // Wait for either cancellation or an interval tick to have passed.
+            tokio::select! {
+                _ = token.cancelled() => {
+                    trace!("Consul session handler was cancelled");
+                    break;
+                },
+                _ = interval.tick() => {},
+            };
+
+            trace!("Renewing Consul session");
+            let res = client
+                .http_client
+                .put(renewal_url.clone())
+                .send()
+                .await
+                .and_then(|res| res.error_for_status());
+            if let Err(err) = res {
+                error!("Renewing Consul session failed, aborting: {err}");
+                token.cancel();
+                return;
+            }
+        }
+
+        trace!("Destroying Consul session");
+        let res = client
+            .http_client
+            .put(destroy_url)
+            .send()
+            .await
+            .and_then(|res| res.error_for_status());
+        if let Err(err) = res {
+            warn!("Destraying Consul session failed: {err}");
+        }
+    })
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,7 +52,6 @@ async fn main() -> Result<()> {
         args.consul_address,
         &args.consul_prefix,
         args.consul_token.as_deref(),
-        args.consul_datacenter,
     )?;
 
     let endpoint_address = if let Some(endpoint_address) = args.endpoint_address {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,6 @@
 mod args;
 
-use std::{
-    collections::{HashMap, HashSet},
-    time::{Duration, Instant},
-};
+use std::collections::HashSet;
 
 use anyhow::{ensure, Context, Result};
 use clap::Parser;
@@ -11,11 +8,7 @@ use tokio::time::sleep;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, trace};
 
-use wiresmith::{
-    consul::ConsulClient,
-    networkd::NetworkdConfiguration,
-    wireguard::{latest_transfer_rx, WgPeer},
-};
+use wiresmith::{consul::ConsulClient, networkd::NetworkdConfiguration, wireguard::WgPeer};
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -86,11 +79,11 @@ async fn main() -> Result<()> {
     }
 
     // Check whether we can find and parse an existing config.
-    let own_public_key = if let Ok(config) =
+    let networkd_config = if let Ok(config) =
         NetworkdConfiguration::from_config(&args.networkd_dir, &args.wg_interface).await
     {
         info!("Successfully loading existing systemd-networkd config");
-        config.public_key
+        config
     } else {
         info!("No existing WireGuard configuration found on system, creating a new one");
 
@@ -106,49 +99,31 @@ async fn main() -> Result<()> {
             .write_config(&args.networkd_dir, args.keepalive)
             .await?;
         info!("Our new config is:\n{:#?}", networkd_config);
-        networkd_config.public_key
+        networkd_config
     };
 
     info!("Restarting systemd-networkd");
     NetworkdConfiguration::restart().await?;
 
-    // Stores amount of received bytes together with a timestamp for every peer.
-    let mut received_bytes: HashMap<wireguard_keys::Pubkey, (usize, Instant)> = HashMap::new();
-
     let consul_session = consul_client
-        .create_session(own_public_key, args.consul_ttl, token.clone())
+        .create_session(networkd_config.public_key, args.consul_ttl, token.clone())
         .await?;
+
+    let own_wg_peer = WgPeer::new(
+        networkd_config.public_key,
+        &format!("{endpoint_address}:{}", args.wg_port),
+        networkd_config.wg_address.addr(),
+    );
+
+    info!("Submitting own WireGuard peer config:\n{:#?}", own_wg_peer);
+    let config_checker = consul_session
+        .put_config(own_wg_peer, token.clone())
+        .await
+        .context("Failed to put own peer config into Consul")?;
+    info!("Wrote own WireGuard peer config to Consul");
 
     // Enter main loop which periodically checks for updates to the list of WireGuard peers.
     loop {
-        if args.peer_timeout > Duration::ZERO {
-            // Fetch latest received bytes from peers. If new bytes were received, update the
-            // hashmap entry. Delete the peer if no new bytes were received for duration
-            // `peer_timeout`.
-            let transfer_rates = latest_transfer_rx(&args.wg_interface)
-                .await
-                .context("Couldn't get list of transfer rates from WireGuard")?;
-            for (pubkey, bytes) in transfer_rates {
-                let (old_bytes, timestamp) = received_bytes
-                    .entry(pubkey)
-                    .or_insert((bytes, Instant::now()));
-                if timestamp.elapsed() > args.peer_timeout && bytes.eq(old_bytes) {
-                    info!(
-                        "Peer {} has exceeded timeout of {:?}, deleting",
-                        pubkey.to_base64_urlsafe(),
-                        args.peer_timeout
-                    );
-                    consul_client
-                        .delete_config(pubkey)
-                        .await
-                        .context("Couldn't delete peer from Consul")?;
-                } else if !bytes.eq(old_bytes) {
-                    *old_bytes = bytes;
-                    *timestamp = Instant::now();
-                }
-            }
-        }
-
         trace!("Checking Consul for peer updates");
         let peers = consul_client
             .get_peers()
@@ -196,32 +171,6 @@ async fn main() -> Result<()> {
                 .context("Error restarting systemd-networkd")?;
         }
 
-        // Add our own peer config to Consul. It could be lacking for two reasons:
-        // 1. Either this is the first run and we were not added to Consul yet.
-        // 2. We were removed due to a timeout (temporary network outage) and have to re-add
-        //    ourselves.
-        let own_peer_is_in_consul = peers
-            .iter()
-            .any(|x| x.public_key == networkd_config.public_key);
-
-        if !own_peer_is_in_consul {
-            info!("Existing WireGuard peer config doesn't yet exist in Consul");
-
-            // Send the config to Consul.
-            let wg_peer = WgPeer::new(
-                networkd_config.public_key,
-                &format!("{endpoint_address}:{}", args.wg_port),
-                networkd_config.wg_address.addr(),
-            );
-            info!("Submitted own WireGuard peer config:\n{:#?}", wg_peer);
-
-            consul_client
-                .put_config(wg_peer)
-                .await
-                .context("Failed to put peer config into Consul")?;
-            info!("Wrote own WireGuard peer config to Consul");
-        }
-
         // Wait until we've either been told to shut down or until we've slept for the update
         // period.
         //
@@ -235,10 +184,17 @@ async fn main() -> Result<()> {
         };
     }
 
+    // Cancel the config checker first so we don't get spurious errors if the session is destroyed
+    // first.
+    config_checker
+        .cancel()
+        .await
+        .context("Failed to join Consul config checker task")?;
+
     // Wait for the Consul session handler to destroy our session and exit. It was cancelled by the
     // same `CancellationToken` that cancelled us.
     consul_session
-        .join_handle
+        .cancel()
         .await
         .context("Failed to join Consul session handler task")?;
 

--- a/src/wireguard.rs
+++ b/src/wireguard.rs
@@ -1,9 +1,7 @@
 use std::{fmt, net::IpAddr};
 
-use anyhow::{ensure, Result};
 use ipnet::IpNet;
 use serde::{Deserialize, Serialize};
-use tokio::process::Command;
 use wireguard_keys::Pubkey;
 
 #[derive(Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
@@ -35,69 +33,5 @@ impl fmt::Debug for WgPeer {
             .field("endpoint", &self.endpoint)
             .field("address", &self.address)
             .finish()
-    }
-}
-
-fn parse_latest_transfer_rx(s: &str) -> Result<Vec<(Pubkey, usize)>> {
-    let mut peers = vec![];
-    for line in s.lines() {
-        let split_line = line.split_ascii_whitespace().collect::<Vec<_>>();
-        peers.push((split_line[0].parse()?, split_line[1].parse()?));
-    }
-    Ok(peers)
-}
-
-/// Get a list of latest received bytes of peers by running 'wg show <interface> transfer'
-pub async fn latest_transfer_rx(interface: &str) -> Result<Vec<(Pubkey, usize)>> {
-    let output = Command::new("wg")
-        .arg("show")
-        .arg(interface)
-        .arg("transfer")
-        .output()
-        .await?;
-    ensure!(
-        output.status.success(),
-        "Couldn't get output of wg show: {:?}",
-        String::from_utf8_lossy(&output.stderr)
-    );
-    let output_reader = std::str::from_utf8(&output.stdout)?;
-
-    parse_latest_transfer_rx(output_reader)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    use pretty_assertions::assert_eq;
-
-    #[test]
-    fn latest_transfer_test() {
-        let transfer_output = "\
-MkgQcW7mlCtqWIV3JrtIrBRgG9efxwSvnXOsU1R7x2c=	304	272
-pKidG6sLcARl/OiB7j8s9yPeo/20fEHuxBi4aamAuVo=	308	272
-MkgQcW7mlCtqWIV3JrtIrBRgG9efxwSvnXOsU1R7x2c=	0 272
-pKidG6sLcARl/OiB7j8s9yPeo/20fEHuxBi4aamAuVo=	0 0";
-
-        let result = parse_latest_transfer_rx(transfer_output).unwrap();
-        let expected = vec![
-            (
-                Pubkey::from_base64("MkgQcW7mlCtqWIV3JrtIrBRgG9efxwSvnXOsU1R7x2c").unwrap(),
-                304,
-            ),
-            (
-                Pubkey::from_base64("pKidG6sLcARl/OiB7j8s9yPeo/20fEHuxBi4aamAuVo").unwrap(),
-                308,
-            ),
-            (
-                Pubkey::from_base64("MkgQcW7mlCtqWIV3JrtIrBRgG9efxwSvnXOsU1R7x2c").unwrap(),
-                0,
-            ),
-            (
-                Pubkey::from_base64("pKidG6sLcARl/OiB7j8s9yPeo/20fEHuxBi4aamAuVo").unwrap(),
-                0,
-            ),
-        ];
-        assert_eq!(result, expected);
     }
 }

--- a/tests/fixtures/mod.rs
+++ b/tests/fixtures/mod.rs
@@ -61,7 +61,6 @@ impl ConsulContainer {
             format!("http://localhost:{port}").parse().unwrap(),
             "wiresmith",
             None,
-            None,
         )
         .unwrap();
         Self {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -375,7 +375,7 @@ async fn join_network_federated_cluster(
         consul_dc1.http_port,
         // This Wiresmith instance is already implicitly connected to dc1. We're just making this
         // explicit here.
-        &["--update-period", "1s", "--consul-datacenter", "dc1"],
+        &["--update-period", "1s"],
         &tmpdir_a,
     )
     .await;
@@ -395,7 +395,7 @@ async fn join_network_federated_cluster(
         // This Wiresmith instance is connected to the Consul in dc2. However, we'll make it use
         // the Consul KV in dc1 so that we have a consistent view of peers as Consul doesn't
         // replicate its KV to federated clusters.
-        &["--update-period", "1s", "--consul-datacenter", "dc1"],
+        &["--update-period", "1s"],
         &tmpdir_b,
     )
     .await;
@@ -428,9 +428,9 @@ async fn join_network_federated_cluster(
     let consul_peers_dc1 = consul_dc1.client.get_peers().await?;
     assert_eq!(consul_peers_dc1, expected_peers);
 
-    // dc2 should have no peers as we were using only dc1.
+    // dc2 should have the same peers as we do in dc1.
     let consul_peers_dc2 = consul_dc2.client.get_peers().await?;
-    assert!(consul_peers_dc2.is_empty());
+    assert_eq!(consul_peers_dc2, consul_peers_dc1);
 
     Ok(())
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -450,8 +450,6 @@ async fn deletes_peer_on_timeout(
     let args = &[
         "--consul-ttl",
         "10s",
-        "--peer-timeout",
-        "10s",
         "--keepalive",
         "1s",
         "--update-period",

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -448,6 +448,8 @@ async fn deletes_peer_on_timeout(
     let consul = consul.await;
     let mut peers: Vec<(WiresmithContainer, WgPeer)> = vec![];
     let args = &[
+        "--consul-ttl",
+        "10s",
         "--peer-timeout",
         "10s",
         "--keepalive",
@@ -553,7 +555,7 @@ async fn deletes_peer_on_timeout(
             )
         });
 
-    // Wait for a little more than the duration `peer_timeout` to trigger the timeout.
+    // Wait for a little more than the duration `consul-ttl` to trigger the timeout.
     sleep(Duration::from_secs(20)).await;
 
     let expected_peers = HashSet::from_iter(remaining_peers.into_iter().map(|peer| peer.1.clone()));


### PR DESCRIPTION
# Background

The old method of deleting stale wiresmith node configurations in Consul by each node keeping track of whether it has received data from the other node recently and otherwise deleting it has a lot of weird edge cases, and ultimately mean that it's easy for one broken node to completely take down the mesh.  To resolve this we want to use Consul sessions to manage the deletion of stale nodes instead, whereby wiresmith holds a Consul session open, locks its own node config under that session, and then continually renews the session.  If the session is ever invalidated, for example because wiresmith crashed and is no longer renewing its session, Consul itself will delete the config.

The simple implementation for this is to continue with the current idea of every node in the mesh writing their configs to the same datacenter, no matter which datacenter the node itself is in, but due to a long-time Consul regression it is not possible to create sessions across datacenters.

As a result of this we need to make wiresmith always write its configuration to the local datacenter, but read node configurations from all available datacenters.  Sadly this means that this PR is a **breaking change** for any deployments working cross-DC.  Nodes in the old primary DC will continue working as before, but nodes in all other DCs will lose contact with each-other until all of them are upgraded.

# New flow

- On startup we create a Consul session and spawn a background task to renew the session.
  - If the session fails to be renewed (for example because some other process invalidated the session explicitly) we cancel the parent task, causing wiresmith to exit and letting the service manager restart us into a clean state.
- Then we put our node config into Consul while acquiring a lock using the previously created session.  This means that if the session is invalidated in any way (either by us explicitly invalidating it on shutdown, or because we crashed and the session timed out) the node config will be automatically deleted by Consul.
  - We then spawn a second background task that makes sure that the node config exists.  If it fails, for example because someone else deleted our config, we again cancel the parent task.

This ended up being a bit more verbose than I'd prefer due to handling the possibility of some other process deleting our node config key, but I feel like this is still the more correct thing to do.

# (Semi)-open questions

- [x] Previously you could have two separate wiresmith meshes in different DCs using the same Consul cluster by simply pointing them at different DCs without having to change the consul prefix, but with this change those separate clusters would now be merged.

  I don't think this is a problem, but it's possible that someone might want the ability to filter the DCs wiresmith operates on.  I think this is something that should only be implemented in the future if there's an actual demand for it, but I felt like it was probably good to mention it anyway.