### PR TITLE
Make container images contain musl binaries

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -95,24 +95,6 @@ jobs:
       - name: Install qemu-user-static
         run: sudo apt update && sudo apt install qemu-user-static
 
-      - name: Download artifact aarch64-unknown-linux-gnu
-        uses: actions/download-artifact@v4
-        with:
-          name: aarch64-unknown-linux-gnu
-          path: target/aarch64-unknown-linux-gnu/release
-
-      - name: Download artifact x86_64-unknown-linux-gnu
-        uses: actions/download-artifact@v4
-        with:
-          name: x86_64-unknown-linux-gnu
-          path: target/x86_64-unknown-linux-gnu/release
-
-      - name: Download artifact armv7-unknown-linux-gnueabihf
-        uses: actions/download-artifact@v4
-        with:
-          name: armv7-unknown-linux-gnueabihf
-          path: target/armv7-unknown-linux-gnueabihf/release
-
       - name: Download artifact aarch64-unknown-linux-musl
         uses: actions/download-artifact@v4
         with:
@@ -135,13 +117,13 @@ jobs:
         run: podman login --username ${{ github.actor }} --password ${{ secrets.GITHUB_TOKEN }} ghcr.io
 
       - name: podman build linux/arm64
-        run: podman build --format docker --platform linux/arm64/v8 --manifest wiresmith -f Containerfile target/aarch64-unknown-linux-gnu/release
+        run: podman build --format docker --platform linux/arm64/v8 --manifest wiresmith -f Containerfile target/aarch64-unknown-linux-musl/release
 
       - name: podman build linux/amd64
-        run: podman build --format docker --platform linux/amd64 --manifest wiresmith -f Containerfile target/x86_64-unknown-linux-gnu/release
+        run: podman build --format docker --platform linux/amd64 --manifest wiresmith -f Containerfile target/x86_64-unknown-linux-musl/release
 
       - name: podman build linux/arm
-        run: podman build --format docker --platform linux/arm/v7 --manifest wiresmith -f Containerfile target/armv7-unknown-linux-gnueabihf/release
+        run: podman build --format docker --platform linux/arm/v7 --manifest wiresmith -f Containerfile target/armv7-unknown-linux-musleabihf/release
 
       - name: podman manifest push latest
         run: podman manifest push wiresmith ghcr.io/svenstaro/wiresmith:latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 <!-- next-header -->
 
 ## [Unreleased] - ReleaseDate
+- Fix container images accidentally containing glibc rather than musl binaries [#215](https://github.com/svenstaro/wiresmith/issues/215)
 
 ## [0.4.3] - 2024-08-30
 - Fix Consul lock session "leak" when the inner loop performed an early return [#212](https://github.com/svenstaro/wiresmith/pull/212)


### PR DESCRIPTION
The container images are based on Alpine images but were accidentally built using the glibc binaries instead of the musl ones, meaning that the container images did not work.